### PR TITLE
Failing spec fix. Spec tweaks to remove deprecation warnings

### DIFF
--- a/method_log.gemspec
+++ b/method_log.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'trollop'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/commit_spec.rb
+++ b/spec/commit_spec.rb
@@ -66,8 +66,8 @@ module MethodLog
         repository = Repository.new(repository_path)
         commit = repository.commits.to_a.last
 
-        expect(commit.contains?(source_file)).to be_true
-        expect(commit.contains?(another_source_file)).to be_false
+        expect(commit.contains?(source_file)).to be true
+        expect(commit.contains?(another_source_file)).to be false
       end
 
       it 'makes author available' do

--- a/spec/method_diff_spec.rb
+++ b/spec/method_diff_spec.rb
@@ -9,8 +9,8 @@ module MethodLog
     let(:diff) { MethodDiff.new(first_commit, second_commit) }
 
     it 'generates text diff of the method source for two commits' do
-      first_commit.stub(:method_source).and_return(%{line 1\nline 2\n})
-      second_commit.stub(:method_source).and_return(%{line 2\nline 3\n})
+      allow(first_commit).to receive(:method_source)  { %{line 1\nline 2\n} }
+      allow(second_commit).to receive(:method_source) { %{line 2\nline 3\n} }
       expect(diff.to_s).to eq(%{-line 1\n line 2\n+line 3\n})
     end
   end

--- a/spec/source_file_spec.rb
+++ b/spec/source_file_spec.rb
@@ -39,7 +39,8 @@ module MethodLog
     end
 
     it 'looks up source in repository using SHA if no source set' do
-      repository.stub(:lookup).with(sha).and_return(blob)
+      allow(repository).to receive(:lookup) { blob }
+      expect(repository).to receive(:lookup).with(sha)
       file = source(path: 'path/to/source.rb', repository: repository, sha: sha)
       expect(file.source).to eq('source')
     end


### PR DESCRIPTION
I recently came across this project from the following [blog](http://gofreerange.com/tracing-the-git-history-of-a-ruby-method) and really loved the idea. I've been going through the codebase to expand upon it so that its functional with Rails projects(Currently running into issues when tracing methods in controllers) . So hopefully this is the first commit of many more to come.

This PR fixes a failing test and removes deprecation warnings being generated as a result of using "stubs"